### PR TITLE
Minor change to menu, and links to documentation

### DIFF
--- a/src/components/DrawerMainNav.vue
+++ b/src/components/DrawerMainNav.vue
@@ -92,15 +92,27 @@
 
       <q-separator spaced/>
 
+      <!--START SUPPORT SELECT-->
+      <q-item
+        clickable
+        to="/ui/settings-support"
+        v-ripple>
+        <q-item-section avatar>
+          <q-icon name="help_outline"/>
+        </q-item-section>
+        <q-item-section>
+          {{ $t('navigation.helpAndSupport') }}
+        </q-item-section>
+      </q-item>
+      <!--END SUPPORT SELECT-->
 
-      <q-item-label header>{{ $t('navigation.documentation') }}:</q-item-label>
       <!--START PRIVACY POLICY-->
       <q-item
         clickable
         @click="showPrivacyPolicyDialog"
         v-ripple>
         <q-item-section avatar>
-          <q-icon name="subject"/>
+          <q-icon name="shield-account"/>
         </q-item-section>
         <q-item-section>
           {{ $t('headers.privacyPolicy') }}

--- a/src/components/DrawerSettingsNav.vue
+++ b/src/components/DrawerSettingsNav.vue
@@ -77,6 +77,19 @@
       </q-item>
       <!--END SUPPORT SELECT-->
 
+      <!--START PRIVACY POLICY-->
+      <q-item
+        clickable
+        @click="showPrivacyPolicyDialog"
+        v-ripple>
+        <q-item-section avatar>
+          <q-icon name="shield-account"/>
+        </q-item-section>
+        <q-item-section>
+          {{ $t('headers.privacyPolicy') }}
+        </q-item-section>
+      </q-item>
+      <!--END PRIVACY POLICY-->
 
     </q-list>
   </q-scroll-area>

--- a/src/pages/SettingsLibrary.vue
+++ b/src/pages/SettingsLibrary.vue
@@ -17,7 +17,9 @@
             >
 
               <!--START LIBRARY PATHS-->
-              <h5 class="q-mb-none">{{ $t('components.settings.library.pathConfiguration') }}</h5>
+              <h5 class="q-mb-none">{{ $t('components.settings.library.pathConfiguration') }}
+                 <a href="https://docs.unmanic.app/docs/configuration/library_settings#library-path-configuration"><i class="on-right material-icons q-icon">help</i></a>
+              </h5>
               <div class="q-gutter-sm">
                 <q-skeleton
                   v-if="libraryPath === null"
@@ -44,7 +46,9 @@
               <q-separator class="q-my-lg"/>
 
               <!--START LIBRARY SCANNER-->
-              <h5 class="q-mb-none">{{ $t('components.settings.library.libraryScanner') }}</h5>
+              <h5 class="q-mb-none">{{ $t('components.settings.library.libraryScanner') }}
+                 <a href="https://docs.unmanic.app/docs/configuration/library_settings#library-scanner"><i class="on-right material-icons q-icon">help</i></a>
+              </h5>
               <div class="q-gutter-sm">
                 <q-skeleton
                   v-if="enableLibraryScanner === null"
@@ -101,7 +105,9 @@
               <q-separator class="q-my-lg"/>
 
               <!--START LIBRARY FILE MONITOR-->
-              <h5 class="q-mb-none">{{ $t('components.settings.library.fileMonitor') }}</h5>
+              <h5 class="q-mb-none">{{ $t('components.settings.library.fileMonitor') }}
+                 <a href="https://docs.unmanic.app/docs/configuration/library_settings#library-file-monitor"><i class="on-right material-icons q-icon">help</i></a>
+              </h5>
               <div class="q-gutter-sm">
                 <q-skeleton
                   v-if="enableLibraryFileMonitor === null"
@@ -117,7 +123,9 @@
               <q-separator class="q-my-lg"/>
 
               <!--START FILE TESTING-->
-              <h5 class="q-mb-none">{{ $t('components.settings.library.fileTesting') }}</h5>
+              <h5 class="q-mb-none">{{ $t('components.settings.library.fileTesting') }}
+                 <a href="https://docs.unmanic.app/docs/configuration/library_settings#pending-tasks"><i class="on-right material-icons q-icon">help</i></a>
+              </h5>
               <div class="q-gutter-sm">
                 <q-skeleton
                   v-if="concurrentFileTesters === null"

--- a/src/pages/SettingsLink.vue
+++ b/src/pages/SettingsLink.vue
@@ -17,7 +17,9 @@
             >
 
               <!--START THIS INSTALLATION-->
-              <h5 class="q-mb-none">{{ $t('components.settings.link.thisInstallation') }}</h5>
+              <h5 class="q-mb-none">{{ $t('components.settings.link.thisInstallation') }}
+                 <a href="https://docs.unmanic.app/docs/configuration/link_settings#name-this-installation"><i class="on-right material-icons q-icon">help</i></a>
+              </h5>
               <div class="q-gutter-sm">
                 <q-skeleton
                   v-if="installationName === null"
@@ -36,7 +38,9 @@
               <q-separator class="q-my-lg"/>
 
               <!--START REMOTE INSTALLATIONS-->
-              <h5 class="q-mb-none">{{ $t('components.settings.link.remoteInstallations') }}</h5>
+              <h5 class="q-mb-none">{{ $t('components.settings.link.remoteInstallations') }}
+                 <a href="https://docs.unmanic.app/docs/configuration/link_settings#remote-installations"><i class="on-right material-icons q-icon">help</i></a>
+              </h5>
               <div class="q-gutter-sm">
                 <q-skeleton
                   v-if="remoteInstallations === null"

--- a/src/pages/SettingsWorkers.vue
+++ b/src/pages/SettingsWorkers.vue
@@ -17,7 +17,9 @@
             >
 
               <!--START WORKER COUNT-->
-              <h5 class="q-mb-none">{{ $t('components.settings.workers.workerCount') }}</h5>
+              <h5 class="q-mb-none">{{ $t('components.settings.workers.workerCount') }}
+                 <a href="https://docs.unmanic.app/docs/configuration/workers_settings#worker-count"><i class="on-right material-icons q-icon">help</i></a>
+              </h5>
               <div class="q-gutter-sm">
                 <q-skeleton
                   v-if="workerCount === null"
@@ -47,7 +49,9 @@
               <q-separator class="q-my-lg"/>
 
               <!--START EVENT SCHEDULE-->
-              <h5 class="q-mb-none">{{ $t('components.settings.workers.schedule') }}</h5>
+              <h5 class="q-mb-none">{{ $t('components.settings.workers.schedule') }}
+                 <a href="https://docs.unmanic.app/docs/configuration/workers_settings#worker-event-schedule"><i class="on-right material-icons q-icon">help</i></a>
+              </h5>
               <div class="q-gutter-sm">
                 <q-skeleton
                   v-if="cachePath === null"
@@ -186,7 +190,9 @@
               <q-separator class="q-my-lg"/>
 
               <!--START CACHE PATHS-->
-              <h5 class="q-mb-none">{{ $t('components.settings.workers.path') }}</h5>
+              <h5 class="q-mb-none">{{ $t('components.settings.workers.path') }}
+                 <a href="https://docs.unmanic.app/docs/configuration/workers_settings#cache-path"><i class="on-right material-icons q-icon">help</i></a>
+              </h5>
               <div class="q-gutter-sm">
                 <q-skeleton
                   v-if="cachePath === null"


### PR DESCRIPTION
I unified the bottom part of the main menu and the settings menu so they both have a link to the Help & Documentation page and a link to the privacy policy. 

I also added inline icons at the end of several headers in the settings area that link to the online documentation site to make it easier for people to get help without opening issues. 