### PR TITLE
Changes copyright to current year

### DIFF
--- a/src/components/FooterData.vue
+++ b/src/components/FooterData.vue
@@ -2,7 +2,7 @@
   <div class="row q-mt-lg">
     <div class="col q-ml-lg">
       <p class="text-subtitle1">
-        &copy; 2018-2021 by <a class="footer-link" target="_blank" href="https://github.com/Josh5">Josh Sunnex</a>
+        &copy; 2018-{{ new Date().getFullYear() }} by <a class="footer-link" target="_blank" href="https://github.com/Josh5">Josh Sunnex</a>
       </p>
     </div>
     <div class="col-auto q-mr-lg">


### PR DESCRIPTION
I’m not familiar with Vue and this is untested in this codebase, but after some quick tests elsewhere, this should work to perpetually keep the copyright year current.

If not, worth updating to 2022 at least!