### PR TITLE
Update processing time to be the same format as ETC

### DIFF
--- a/src/js/dateTools.js
+++ b/src/js/dateTools.js
@@ -1,17 +1,13 @@
 import { date } from 'quasar';
 
 export default {
-  printTimeSinceDate(startDate) {
-    let date_now = new Date();
+  printSecondsAsDuration(timestamp) {
+    timestamp = Number(timestamp);
 
-    let seconds = Math.floor((date_now - (startDate)) / 1000);
-    let minutes = Math.floor(seconds / 60);
-    let hours = Math.floor(minutes / 60);
-    let days = Math.floor(hours / 24);
-
-    hours = hours - (days * 24);
-    minutes = minutes - (days * 24 * 60) - (hours * 60);
-    seconds = seconds - (days * 24 * 60 * 60) - (hours * 60 * 60) - (minutes * 60);
+    const days = Math.floor(timestamp / 3600 / 24);
+    const hours = Math.floor((timestamp / 3600) % 24);
+    const minutes = Math.floor((timestamp % 3600) / 60);
+    const seconds = Math.floor((timestamp % 3600) % 60);
 
     const dDisplay = days > 0 ? days + (days == 1 ? " day, " : " days, ") : "";
     const hDisplay = hours > 0 ? hours + (hours == 1 ? " hour, " : " hours, ") : "";
@@ -19,17 +15,6 @@ export default {
     const sDisplay = seconds > 0 ? seconds + (seconds == 1 ? " second" : " seconds") : "";
 
     return dDisplay + hDisplay + mDisplay + sDisplay;
-  },
-  printTimeAsHoursMinsSeconds(timestamp) {
-    timestamp = Number(timestamp);
-    let hours = Math.floor(timestamp / 3600);
-    let minutes = Math.floor(timestamp % 3600 / 60);
-    let seconds = Math.floor(timestamp % 3600 % 60);
-
-    let hDisplay = hours > 0 ? hours + (hours == 1 ? " hour, " : " hours, ") : "";
-    let mDisplay = minutes > 0 ? minutes + (minutes == 1 ? " minute, " : " minutes, ") : "";
-    let sDisplay = seconds > 0 ? seconds + (seconds == 1 ? " second" : " seconds") : "";
-    return hDisplay + mDisplay + sDisplay;
   },
   printDateTimeString(dateTime) {
     let d = new Date(0);

--- a/src/js/dateTools.js
+++ b/src/js/dateTools.js
@@ -14,7 +14,9 @@ export default {
     const mDisplay = minutes > 0 ? minutes + (minutes == 1 ? " minute, " : " minutes, ") : "";
     const sDisplay = seconds > 0 ? seconds + (seconds == 1 ? " second" : " seconds") : "";
 
-    return dDisplay + hDisplay + mDisplay + sDisplay;
+    duration = dDisplay + hDisplay + mDisplay + sDisplay;
+
+    return duration.replace(/, $/, '');
   },
   printDateTimeString(dateTime) {
     let d = new Date(0);

--- a/src/js/dateTools.js
+++ b/src/js/dateTools.js
@@ -13,7 +13,12 @@ export default {
     minutes = minutes - (days * 24 * 60) - (hours * 60);
     seconds = seconds - (days * 24 * 60 * 60) - (hours * 60 * 60) - (minutes * 60);
 
-    return "Days: " + days + " Hours: " + hours + " Minutes: " + minutes + " Seconds: " + seconds;
+    const dDisplay = days > 0 ? days + (days == 1 ? " day, " : " days, ") : "";
+    const hDisplay = hours > 0 ? hours + (hours == 1 ? " hour, " : " hours, ") : "";
+    const mDisplay = minutes > 0 ? minutes + (minutes == 1 ? " minute, " : " minutes, ") : "";
+    const sDisplay = seconds > 0 ? seconds + (seconds == 1 ? " second" : " seconds") : "";
+
+    return dDisplay + hDisplay + mDisplay + sDisplay;
   },
   printTimeAsHoursMinsSeconds(timestamp) {
     timestamp = Number(timestamp);

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -234,9 +234,9 @@ export default {
           workerData['worker-' + worker.id].currentRunner = currentRunner;
 
           // Set the start and total processing time
-          let startTime = new Date(worker.start_time * 1000);
+          const processingDuration = (new Date() - new Date(worker.start_time * 1000)) / 1000;
           workerData['worker-' + worker.id].startTime = dateTools.printDateTimeString(worker.start_time);
-          workerData['worker-' + worker.id].totalProcTime = dateTools.printTimeSinceDate(startTime);
+          workerData['worker-' + worker.id].totalProcTime = dateTools.printSecondsAsDuration(processingDuration);
 
           // Set the worker log file
           workerData['worker-' + worker.id].workerLog = worker.worker_log_tail;
@@ -249,8 +249,8 @@ export default {
             workerData['worker-' + worker.id].progressText = worker.subprocess.percent + '%';
 
             // Set the ETC
-            workerData['worker-' + worker.id].etc = dateTools.printTimeAsHoursMinsSeconds(calculateEtc(worker.subprocess.percent, worker.subprocess.elapsed));
-
+            const etcDuration = calculateEtc(worker.subprocess.percent, worker.subprocess.elapsed)
+            workerData['worker-' + worker.id].etc = dateTools.printSecondsAsDuration(etcDuration);
           } else {
             // Set progress as 'indeterminate' if no progress is given
             workerData['worker-' + worker.id].indeterminate = true;


### PR DESCRIPTION
Currently the `ETC` time format and the `Total Processing Time` format are different. This initially made me think that the processing time was just wrong (since I read this screenshot as processing for 4 seconds and completely missed the 31 at the end of the line).

This MR should change the format of the `Total Processing Time` to be the same as the `ETC` format and only show days/hours as needed.

## ETC for reference

![image](https://github.com/Unmanic/unmanic-frontend/assets/115825/64222bc7-fbca-4454-8bd5-7b0c834767f0)

## Existing

![image](https://github.com/Unmanic/unmanic-frontend/assets/115825/9f8b9529-6657-428f-8bfb-b592b75ada22)

## New

![image](https://github.com/Unmanic/unmanic-frontend/assets/115825/0ffdb2e3-8e60-4cf2-9188-33add26c4e09)

`printTimeSinceDate` is only referenced in one place, within `Dashboard.vue`, so there shouldn't be any issues with the changes.
