### PR TITLE
Fix mobile back arrow and back swipe not saving library config

### DIFF
--- a/src/components/dialogs/ConfigDrawerDialog.vue
+++ b/src/components/dialogs/ConfigDrawerDialog.vue
@@ -40,7 +40,6 @@
               round
               flat
               icon="arrow_back"
-              v-close-popup
               @click="cancel">
             </q-btn>
           </div>

--- a/src/components/dialogs/ConfigDrawerDialog.vue
+++ b/src/components/dialogs/ConfigDrawerDialog.vue
@@ -26,7 +26,7 @@
     @hide="onDialogHide">
 
     <q-card
-      v-touch-swipe.touch.right="hide"
+      v-touch-swipe.touch.right="cancel"
       :style="$q.platform.is.mobile ? 'max-width:100vw;' : `max-width:95vw; width:${width};`">
 
       <q-card-section class="bg-card-head dialog-sticky-header">
@@ -40,7 +40,8 @@
               round
               flat
               icon="arrow_back"
-              v-close-popup>
+              v-close-popup
+              @click="cancel">
             </q-btn>
           </div>
 


### PR DESCRIPTION
So the back arrow (and swipe from left to right) on the Library config would exit without saving. This is unlike the desktop where the X button saves. So I fixed that. This was likely due to an unused save vs cancel and discard changes functionality that theses function differently. 