### PR TITLE
Debounce input to textarea and text input fields

### DIFF
--- a/src/components/settings/plugins/PluginInfoDialog.vue
+++ b/src/components/settings/plugins/PluginInfoDialog.vue
@@ -134,6 +134,7 @@
                           <q-input
                             filled
                             v-model="item.value"
+                            debounce="500"
                             :bottom-slots="item.description.length > 0"
                             :disable="item.display === 'disabled'"
                             :label="item.label"
@@ -152,6 +153,7 @@
                           <q-input
                             filled
                             v-model="item.value"
+                            debounce="500"
                             type="textarea"
                             :bottom-slots="item.description.length > 0"
                             :disable="item.display === 'disabled'"


### PR DESCRIPTION
Currently, Unmanic saves changed plugin settings on every keystroke in a textarea or input field. This can cause issues like vanishing characters because the front-end is reading back the changes afterwards. 

This PR adds debouncing to textarea and text input fields so that changes are applied 500ms after the last keystroke.