### PR TITLE
Wrap long task labels in the completed tasks dashboard card

### DIFF
--- a/src/components/dashboard/completed/CompletedTasksDashboardSection.vue
+++ b/src/components/dashboard/completed/CompletedTasksDashboardSection.vue
@@ -180,4 +180,10 @@ export default defineComponent({
     padding: 8px 6px;
   }
 }
+
+.completed-tasks-card-body :deep(.q-item__label) {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
 </style>


### PR DESCRIPTION
## Problem

Long file names in the **completed tasks** dashboard card overflow the card box horizontally.

The **pending tasks** card had this exact issue fixed with a wrap rule on its item labels (`white-space: normal; overflow-wrap: anywhere; word-break: break-word`), but the structurally-identical completed tasks card was missed — it has no overflow handling on `.q-item__label`.

## Fix

Mirror the same scoped rule for `.completed-tasks-card-body`.

Verified visually by injecting the equivalent override into the compiled CSS on a live install (Unmanic `0.4.0+e838573`) with a library full of long TV episode names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)